### PR TITLE
fix(ci): quote python-version to prevent YAML parsing as float

### DIFF
--- a/.github/workflows/playwright-ci.yml
+++ b/.github/workflows/playwright-ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        python-version: [3.10]
+        python-version: ['3.10']
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the CI failure where python-version was being parsed as 3.1 instead of '3.10'.

The YAML parser was treating 3.10 as a float (3.1), causing Python setup to fail.

This PR quotes the version string to ensure proper parsing.

Fixes #3