### PR TITLE
fix(ci): add server/requirements.txt for CI dependency installation

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.104.0
+uvicorn[standard]>=0.24.0
+pydantic>=2.0.0
+python-multipart>=0.0.6
+websockets>=11.0


### PR DESCRIPTION
Fixes the CI failure by adding the missing requirements.txt file.

Includes:
- fastapi>=0.104.0
- uvicorn[standard]>=0.24.0
- pydantic>=2.0.0
- python-multipart>=0.0.6
- websockets>=11.0

This resolves the error: 'Could not open requirements file: server/requirements.txt'

Closes #3